### PR TITLE
fix(runtime): bind loopback and skip the server in release builds

### DIFF
--- a/src/addon/godot_mcp_runtime/mcp_runtime_autoload.gd
+++ b/src/addon/godot_mcp_runtime/mcp_runtime_autoload.gd
@@ -5,6 +5,8 @@ extends Node
 ## It starts a TCP server that the MCP server can connect to.
 
 const DEFAULT_PORT = 7777
+const DEFAULT_BIND_ADDRESS = "127.0.0.1"
+const BIND_ADDRESS_SETTING = "godot_mcp/runtime/bind_address"
 const PROTOCOL_VERSION = "1.0"
 
 var _server: TCPServer
@@ -68,8 +70,16 @@ func _process(_delta: float) -> void:
 
 
 func _start_server() -> void:
+	# The command set includes call_method, set_property and input injection, none of it
+	# authenticated, so a release export must not serve it.
+	if not OS.is_debug_build():
+		_enabled = false
+		return
+
 	_server = TCPServer.new()
-	var error = _server.listen(_port)
+	# listen() defaults bind_address to "*", which exposes the game to the whole network.
+	var bind_address = str(ProjectSettings.get_setting(BIND_ADDRESS_SETTING, DEFAULT_BIND_ADDRESS))
+	var error = _server.listen(_port, bind_address)
 	if error != OK:
 		push_error("[MCP Runtime] Failed to start server on port %d: %s" % [_port, error])
 		_enabled = false


### PR DESCRIPTION
`_start_server` calls `listen(_port)` with one argument, so `bind_address` defaults to `"*"` and the socket is reachable from the whole network. It also starts in every build, release exports included.

The command set includes `call_method` (`node.callv` on any node in the tree), `set_property`, screenshot capture and input injection, none of it authenticated. So a shipped game currently serves that to the LAN.

Two changes:

- skip the server unless `OS.is_debug_build()`
- default the bind to `127.0.0.1`, overridable with a `godot_mcp/runtime/bind_address` project setting so remote-device debugging still works

Editor and same-machine debug exports behave as before.