### PR TITLE
fix(project): parse multi-line values in project.godot

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -121,13 +121,47 @@ function ensureAllowedExtension(kind: 'scene' | 'script' | 'resource', filePath:
   }
 }
 
-function parseProjectGodot(content: string): Record<string, Record<string, string | number | boolean | null>> {
+// Godot writes dictionaries, arrays and Object(...) values across several lines, so a
+// value is only finished once its brackets balance outside of a string.
+function isValueComplete(value: string): boolean {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (const character of value) {
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (character === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (character === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) {
+      continue;
+    }
+    if (character === '{' || character === '[' || character === '(') {
+      depth += 1;
+    } else if (character === '}' || character === ']' || character === ')') {
+      depth -= 1;
+    }
+  }
+
+  return depth <= 0 && !inString;
+}
+
+export function parseProjectGodot(content: string): Record<string, Record<string, string | number | boolean | null>> {
   const result: Record<string, Record<string, string | number | boolean | null>> = {};
   let currentSection = 'root';
   result[currentSection] = {};
 
-  for (const rawLine of content.split(/\r?\n/)) {
-    const line = rawLine.trim();
+  const lines = content.split(/\r?\n/);
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index].trim();
     if (!line || line.startsWith(';') || line.startsWith('#')) {
       continue;
     }
@@ -146,7 +180,12 @@ function parseProjectGodot(content: string): Record<string, Record<string, strin
     }
 
     const key = line.slice(0, eqIndex).trim();
-    const rawValue = line.slice(eqIndex + 1).trim();
+    let rawValue = line.slice(eqIndex + 1).trim();
+
+    while (index + 1 < lines.length && !isValueComplete(rawValue)) {
+      index += 1;
+      rawValue += `\n${lines[index].trim()}`;
+    }
 
     result[currentSection][key] = parseIniLikeValue(rawValue);
   }

--- a/test-regressions.mjs
+++ b/test-regressions.mjs
@@ -9,6 +9,7 @@ import { spawn } from 'node:child_process';
 import { spawnSync } from 'node:child_process';
 import { setTimeout as delay } from 'node:timers/promises';
 import { createBridge } from './build/godot-bridge.js';
+import { parseProjectGodot } from './build/resources.js';
 
 const INDEX_SOURCE = readFileSync(new URL('./src/index.ts', import.meta.url), 'utf8');
 const CLI_NOTIFY_SOURCE = readFileSync(new URL('./src/cli/notify.ts', import.meta.url), 'utf8');
@@ -210,6 +211,60 @@ async function testEditorStatusPortConflict() {
   });
 }
 
+function testProjectGodotMultilineValues() {
+  const parsed = parseProjectGodot(
+    [
+      '[input]',
+      '',
+      'move_left={',
+      '"deadzone": 0.2,',
+      '"events": [Object(InputEventKey,"physical_keycode":65)]',
+      '}',
+      '',
+      '[rendering]',
+      '',
+      'renderer/rendering_method="gl_compatibility"',
+      '',
+      '[misc]',
+      '',
+      'brace_in_string="{"',
+      'after_brace_in_string="kept"',
+      'inline_dict={"x": [1, 2], "y": {"z": 3}}',
+      'after_inline_dict=7',
+    ].join('\n'),
+  );
+
+  assert.equal(
+    parsed.input?.move_left,
+    '{\n"deadzone": 0.2,\n"events": [Object(InputEventKey,"physical_keycode":65)]\n}',
+    'multi-line dictionary values should be joined rather than truncated to their first line',
+  );
+  assert.equal(
+    parsed.rendering?.['renderer/rendering_method'],
+    'gl_compatibility',
+    'a section following a multi-line value should still be parsed',
+  );
+  assert.equal(
+    parsed.misc?.brace_in_string,
+    '{',
+    'a brace inside a quoted string should not start a continuation',
+  );
+  assert.equal(
+    parsed.misc?.after_brace_in_string,
+    'kept',
+    'a key after a quoted brace should survive',
+  );
+  assert.equal(
+    parsed.misc?.inline_dict,
+    '{"x": [1, 2], "y": {"z": 3}}',
+    'a balanced single-line dictionary should be left alone',
+  );
+  assert.equal(parsed.misc?.after_inline_dict, 7, 'a key after an inline dictionary should survive');
+
+  const unterminated = parseProjectGodot('[s]\nbroken={\n"k": 1\n');
+  assert.equal(typeof unterminated.s?.broken, 'string', 'an unterminated value should not hang');
+}
+
 async function main() {
   testStaleDisconnectRegression();
   testSceneToolsVectorRegression();
@@ -267,6 +322,7 @@ async function main() {
     'runtime key injection should treat string keycode values as key labels',
   );
 
+  testProjectGodotMultilineValues();
   await testEditorStatusPortConflict();
   console.log('regression tests passed');
 }


### PR DESCRIPTION
`parseProjectGodot` reads one line at a time, so any value Godot wrote across several lines is truncated to its first fragment. `godot://project/info` returns `"{"`.

Hits every project with custom input actions, since Godot always writes those multi-line:

```
move_left={
"deadzone": 0.2,
"events": [Object(InputEventKey,"physical_keycode":65)]
}
```

Before: `input/move_left` is `"{"`. After: the whole dictionary.

Joins continuation lines until brackets balance outside a string, so `a="{"` and `a={"x": [1, 2]}` are untouched and an unterminated value stops at EOF instead of hanging.

Exported the function and added regression tests covering the multi-line case, a following section, a brace inside a string, an inline nested dictionary and the unterminated case. Verified they fail without the fix.

`bun run ci` passes. Checked against a real project.godot with 50+ keys: one key changed, the broken one.