### PR TITLE
fix(lsp): match diagnostics when Godot re-encodes the file URI

### DIFF
--- a/src/lsp_client.ts
+++ b/src/lsp_client.ts
@@ -11,10 +11,35 @@ type PendingRequest = {
 
 type DiagnosticsWaiter = {
   resolve: (diagnostics: unknown[]) => void;
+  reject: (reason?: unknown) => void;
   timer: NodeJS.Timeout;
 };
 
 type JsonRecord = Record<string, unknown>;
+
+const DIAGNOSTICS_TIMEOUT_MS = 5000;
+
+/**
+ * Normalise a file URI so the same file always produces the same key.
+ *
+ * Godot and Node spell a Windows path differently. Since Godot 4.5 the language server
+ * encodes URIs per RFC 3986, which percent-encodes the drive colon:
+ *
+ *   Godot: file:///C%3A/Users/me/game/player.gd
+ *   Node:  file:///C:/Users/me/game/player.gd    (pathToFileURL, per WHATWG URL)
+ *
+ * Both are valid and both name the same file, but they are not equal as strings, so a
+ * waiter registered under one is never found under the other. Decoding puts them in the
+ * same shape. On Linux and macOS there is no drive letter, the two already agree, and this
+ * is a no-op.
+ */
+function diagnosticsKey(uri: string): string {
+  try {
+    return decodeURIComponent(uri);
+  } catch {
+    return uri;
+  }
+}
 
 export class GodotLSPClient {
   private socket: Socket | null = null;
@@ -110,8 +135,9 @@ export class GodotLSPClient {
       }, 1000);
     });
 
-    this.rejectAllPending(new Error('Disconnected from Godot LSP'));
-    this.resolveAllDiagnosticsWaiters([]);
+    const disconnected = new Error('Disconnected from Godot LSP');
+    this.rejectAllPending(disconnected);
+    this.rejectAllDiagnosticsWaiters(disconnected);
   }
 
   private async ensureConnected(): Promise<void> {
@@ -265,10 +291,11 @@ export class GodotLSPClient {
           ? (paramsObject.diagnostics as unknown[])
           : [];
         if (typeof uri === 'string') {
-          const waiter = this.diagnosticsWaiters.get(uri);
+          const key = diagnosticsKey(uri);
+          const waiter = this.diagnosticsWaiters.get(key);
           if (waiter) {
             clearTimeout(waiter.timer);
-            this.diagnosticsWaiters.delete(uri);
+            this.diagnosticsWaiters.delete(key);
             waiter.resolve(diagnostics);
           }
         }
@@ -280,16 +307,18 @@ export class GodotLSPClient {
     this.connected = false;
     this.initialized = false;
     this.socket = null;
-    this.rejectAllPending(new Error(`Godot LSP connection error: ${error.message}`));
-    this.resolveAllDiagnosticsWaiters([]);
+    const failure = new Error(`Godot LSP connection error: ${error.message}`);
+    this.rejectAllPending(failure);
+    this.rejectAllDiagnosticsWaiters(failure);
   }
 
   private handleSocketClose(): void {
     this.connected = false;
     this.initialized = false;
     this.socket = null;
-    this.rejectAllPending(new Error('Godot LSP socket closed'));
-    this.resolveAllDiagnosticsWaiters([]);
+    const closed = new Error('Godot LSP socket closed');
+    this.rejectAllPending(closed);
+    this.rejectAllDiagnosticsWaiters(closed);
   }
 
   private rejectAllPending(error: Error): void {
@@ -300,10 +329,14 @@ export class GodotLSPClient {
     });
   }
 
-  private resolveAllDiagnosticsWaiters(diagnostics: unknown[]): void {
+  /**
+   * Fail every waiter, for the same reason the timeout does: a lost connection is not a
+   * file without problems, and resolving [] here reports one as the other.
+   */
+  private rejectAllDiagnosticsWaiters(error: Error): void {
     this.diagnosticsWaiters.forEach((waiter, uri) => {
       clearTimeout(waiter.timer);
-      waiter.resolve(diagnostics);
+      waiter.reject(error);
       this.diagnosticsWaiters.delete(uri);
     });
   }
@@ -388,21 +421,30 @@ export class GodotLSPClient {
     await this.ensureConnected();
     await this.ensureInitializedForFile(filePath);
 
-    const uri = this.toFileUri(filePath);
+    const key = diagnosticsKey(this.toFileUri(filePath));
 
-    const diagnosticsPromise = new Promise<unknown[]>((resolveDiagnostics) => {
-      const existing = this.diagnosticsWaiters.get(uri);
+    const diagnosticsPromise = new Promise<unknown[]>((resolveDiagnostics, rejectDiagnostics) => {
+      const existing = this.diagnosticsWaiters.get(key);
       if (existing) {
         clearTimeout(existing.timer);
       }
 
       const timer = setTimeout(() => {
-        this.diagnosticsWaiters.delete(uri);
-        resolveDiagnostics([]);
-      }, 5000);
+        this.diagnosticsWaiters.delete(key);
+        // Not an empty array. Godot publishes an empty diagnostics list for a file that
+        // really is clean, so resolving [] here makes a broken language server look
+        // exactly like healthy code, and the caller has no way to tell the two apart.
+        rejectDiagnostics(
+          new Error(
+            `Godot published no diagnostics for ${key} within ${DIAGNOSTICS_TIMEOUT_MS}ms. ` +
+              'The language server may not be running, or may not have this file in its workspace.',
+          ),
+        );
+      }, DIAGNOSTICS_TIMEOUT_MS);
 
-      this.diagnosticsWaiters.set(uri, {
+      this.diagnosticsWaiters.set(key, {
         resolve: resolveDiagnostics,
+        reject: rejectDiagnostics,
         timer,
       });
     });
@@ -411,10 +453,10 @@ export class GodotLSPClient {
       this.syncDocument(filePath, content);
       return await diagnosticsPromise;
     } catch (error) {
-      const waiter = this.diagnosticsWaiters.get(uri);
+      const waiter = this.diagnosticsWaiters.get(key);
       if (waiter) {
         clearTimeout(waiter.timer);
-        this.diagnosticsWaiters.delete(uri);
+        this.diagnosticsWaiters.delete(key);
       }
       throw error;
     }

--- a/test-regressions.mjs
+++ b/test-regressions.mjs
@@ -9,6 +9,7 @@ import { spawn } from 'node:child_process';
 import { spawnSync } from 'node:child_process';
 import { setTimeout as delay } from 'node:timers/promises';
 import { createBridge } from './build/godot-bridge.js';
+import { GodotLSPClient } from './build/lsp_client.js';
 
 const INDEX_SOURCE = readFileSync(new URL('./src/index.ts', import.meta.url), 'utf8');
 const CLI_NOTIFY_SOURCE = readFileSync(new URL('./src/cli/notify.ts', import.meta.url), 'utf8');
@@ -165,6 +166,123 @@ function testSceneToolsVectorRegression() {
   }
 }
 
+/**
+ * A stand-in for Godot's language server.
+ *
+ * `reply` decides what URI it publishes diagnostics under, which is the whole point: Godot
+ * does not echo back the URI the client sent, it builds its own.
+ */
+async function withFakeLanguageServer(publishUri, handler) {
+  const sockets = new Set();
+
+  const server = createServer((socket) => {
+    sockets.add(socket);
+    let buffer = '';
+
+    const send = (message) => {
+      const body = JSON.stringify(message);
+      socket.write(`Content-Length: ${Buffer.byteLength(body)}\r\n\r\n${body}`);
+    };
+
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString();
+      while (true) {
+        const headerEnd = buffer.indexOf('\r\n\r\n');
+        if (headerEnd === -1) return;
+        const length = Number(/content-length:\s*(\d+)/i.exec(buffer.slice(0, headerEnd))?.[1]);
+        if (!Number.isFinite(length)) return;
+        const start = headerEnd + 4;
+        if (buffer.length < start + length) return;
+
+        const message = JSON.parse(buffer.slice(start, start + length));
+        buffer = buffer.slice(start + length);
+
+        if (message.method === 'initialize') {
+          send({ jsonrpc: '2.0', id: message.id, result: { capabilities: {} } });
+        } else if (message.method === 'textDocument/didOpen') {
+          const uri = publishUri(message.params.textDocument.uri);
+          if (uri !== null) {
+            send({
+              jsonrpc: '2.0',
+              method: 'textDocument/publishDiagnostics',
+              params: {
+                uri,
+                diagnostics: [{
+                  range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+                  message: 'Could not find type "Missing" in the current scope.',
+                  severity: 1,
+                  source: 'gdscript',
+                }],
+              },
+            });
+          }
+        }
+      }
+    });
+    socket.on('error', () => {});
+  });
+
+  await new Promise((ready) => server.listen(0, '127.0.0.1', ready));
+
+  try {
+    return await handler(server.address().port);
+  } finally {
+    for (const socket of sockets) socket.destroy();
+    await new Promise((closed) => server.close(closed));
+  }
+}
+
+/**
+ * Godot builds its own file URI rather than echoing the client's, and since 4.5 it encodes
+ * per RFC 3986, which escapes characters Node's pathToFileURL leaves bare. On Windows the
+ * real case is the drive colon: the client sends `file:///C:/game/player.gd` and Godot
+ * answers `file:///C%3A/game/player.gd`. Both name the same file and are not equal as
+ * strings, so a waiter keyed on one is never found under the other, the wait times out and
+ * every file comes back with no problems.
+ *
+ * Re-encoding one character of the basename reproduces exactly that mismatch on any
+ * platform, without needing a Windows drive letter to do it.
+ */
+async function testDiagnosticsSurviveUriReEncoding() {
+  const reEncodeFirstLetter = (uri) => {
+    const at = uri.lastIndexOf('/') + 1;
+    const code = uri.charCodeAt(at).toString(16).toUpperCase();
+    return `${uri.slice(0, at)}%${code}${uri.slice(at + 1)}`;
+  };
+
+  await withFakeLanguageServer(reEncodeFirstLetter, async (port) => {
+    const client = new GodotLSPClient(port, '127.0.0.1');
+    const diagnostics = await client.getDiagnostics(
+      join(tmpdir(), 'gopeak-lsp-regression', 'player.gd'),
+      'extends Node\n',
+    );
+
+    assert.equal(
+      diagnostics.length,
+      1,
+      'diagnostics published under a differently encoded but identical URI should still reach the caller',
+    );
+    await client.disconnect?.();
+  });
+}
+
+/**
+ * Godot publishes an empty diagnostics array for a file that really is clean, so a wait
+ * that gives up must not answer with one too. Reporting a dead language server as a clean
+ * file is the failure that hides itself.
+ */
+async function testDiagnosticsTimeoutIsNotAnEmptyResult() {
+  await withFakeLanguageServer(() => null, async (port) => {
+    const client = new GodotLSPClient(port, '127.0.0.1');
+    await assert.rejects(
+      () => client.getDiagnostics(join(tmpdir(), 'gopeak-lsp-regression', 'silent.gd'), 'extends Node\n'),
+      /published no diagnostics/,
+      'a diagnostics wait that times out should fail rather than report an empty result',
+    );
+    await client.disconnect?.();
+  });
+}
+
 async function testEditorStatusPortConflict() {
   await withOccupiedBridgePort(async () => {
     const proc = spawn(process.execPath, ['./build/index.js'], {
@@ -268,6 +386,8 @@ async function main() {
   );
 
   await testEditorStatusPortConflict();
+  await testDiagnosticsSurviveUriReEncoding();
+  await testDiagnosticsTimeoutIsNotAnEmptyResult();
   console.log('regression tests passed');
 }
 


### PR DESCRIPTION
On Windows `lsp_get_diagnostics` returns an empty list for every file, so everything looks clean.

The waiter is keyed on the URI from `pathToFileURL` (`file:///C:/...`). Godot builds its own and percent-encodes the drive colon (`file:///C%3A/...`), so the map lookup misses and the 5s timer wins. Godot 4.4 echoed the client's URI back, which is why this only shows up on 4.5+ (godotengine/godot#104401). Decoding both sides gives one key, and it is a no-op where there is no drive colon.

Second thing: that timeout resolved `[]`. Godot publishes an empty array for a file that really is clean, so a dead language server and healthy code gave the same answer. It rejects now, and socket close and socket error do the same instead of resolving `[]`.

Two regression tests drive a fake language server. Both fail on main, the first with 0 diagnostics instead of 1.

`bun run ci` passes.
