### PR TITLE
feat(editor): add a rescan_filesystem tool

### DIFF
--- a/src/addon/godot_mcp_editor/tool_executor.gd
+++ b/src/addon/godot_mcp_editor/tool_executor.gd
@@ -70,6 +70,7 @@ func _init_tools() -> void:
 		"connect_signal": [_scene_tools, "connect_signal"],
 		"disconnect_signal": [_scene_tools, "disconnect_signal"],
 		"list_connections": [_scene_tools, "list_connections"],
+		"rescan_filesystem": [_scene_tools, "rescan_filesystem"],
 
 		# Resource tools
 		"create_resource": [_resource_tools, "create_resource"],

--- a/src/addon/godot_mcp_editor/tools/scene_tools.gd
+++ b/src/addon/godot_mcp_editor/tools/scene_tools.gd
@@ -759,3 +759,30 @@ func list_connections(args: Dictionary) -> Dictionary:
 
 	root.queue_free()
 	return {"ok": true, "connections": connections}
+
+
+## Rescan the project filesystem, and report whether a scan is still running.
+##
+## The editor rescans when its window regains focus, so a script written by anything other
+## than the editor stays invisible until someone clicks on Godot. Until then its
+## `class_name` is missing from the global class list and the language server reports every
+## use of it as an unknown type, which is godotengine/godot#42786.
+##
+## Returns as soon as the scan is queued rather than awaiting it, because the tool executor
+## takes a Dictionary and not a coroutine. Pass `statusOnly` to poll without starting
+## another scan.
+func rescan_filesystem(args: Dictionary) -> Dictionary:
+	if not _editor_plugin:
+		return {"ok": false, "error": "Editor plugin unavailable"}
+
+	var filesystem := _editor_plugin.get_editor_interface().get_resource_filesystem()
+	if not bool(args.get("statusOnly", false)):
+		filesystem.scan()
+
+	# Importing is reported separately from scanning, and a class is not registered until
+	# both are done, so a caller watching only one of them can look too early.
+	return {
+		"ok": true,
+		"scanning": filesystem.is_scanning(),
+		"importing": filesystem.is_importing()
+	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,6 +138,7 @@ class GodotServer {
     'scene.create': 'create_scene',
     'scene.save': 'save_scene',
     'scene.nodes': 'list_scene_nodes',
+    'project.rescan': 'rescan_filesystem',
     'scene.node.add': 'add_node',
     'scene.node.properties': 'get_node_properties',
     'scene.node.set': 'set_node_properties',
@@ -1626,6 +1627,8 @@ class GodotServer {
           return await this.handleGetUid(request.params.arguments);
         case 'update_project_uids':
           return await this.handleUpdateProjectUids(request.params.arguments);
+        case 'rescan_filesystem':
+          return await this.handleRescanFilesystem(normalizedArgs);
         // Phase 1: Scene Operations handlers
         case 'list_scene_nodes':
           return await this.handleViaBridge('list_scene_nodes', normalizedArgs);
@@ -2020,6 +2023,45 @@ class GodotServer {
    * Route a tool call through the Godot Editor Plugin bridge (WebSocket).
    * Returns an error response if the editor is not connected.
    */
+  /**
+   * Rescan the project filesystem, and wait for the scan to finish.
+   *
+   * The waiting is here rather than in the addon because the editor-side tool executor
+   * takes a Dictionary back and not a coroutine, so the addon can only start the scan and
+   * report whether one is running. A caller that has just written a script needs the scan
+   * to have landed before the new class_name is resolvable, so this polls until it has.
+   */
+  private async handleRescanFilesystem(args: any): Promise<any> {
+    const timeoutMs = Number.isFinite(Number(args?.timeoutMs)) ? Number(args.timeoutMs) : 10000;
+    const started = Date.now();
+
+    const first = await this.handleViaBridge('rescan_filesystem', args);
+    if (first?.isError) {
+      return first;
+    }
+
+    let busy = true;
+    while (busy && Date.now() - started < timeoutMs) {
+      await new Promise((settle) => setTimeout(settle, 100));
+      const status = await this.godotBridge.invokeTool('rescan_filesystem', {
+        ...(args || {}),
+        statusOnly: true,
+      }) as Record<string, unknown>;
+      busy = Boolean(status?.scanning) || Boolean(status?.importing);
+    }
+
+    return {
+      content: [{ type: 'text', text: JSON.stringify({
+        ok: !busy,
+        stillWorking: busy,
+        waitedMs: Date.now() - started,
+        note: busy
+          ? 'The editor was still scanning or importing when the wait ran out, so new files may not be visible yet.'
+          : undefined,
+      }, null, 2) }],
+    };
+  }
+
   private async handleViaBridge(toolName: string, args: any): Promise<any> {
     if (!this.godotBridge.isConnected()) {
       return {

--- a/src/tool-definitions.ts
+++ b/src/tool-definitions.ts
@@ -457,6 +457,24 @@ export function buildToolDefinitions(godotBridgePort: number): MCPToolDefinition
         // Phase 1: Scene Operations (V3 Enhancement)
         // ============================================
         {
+          name: 'rescan_filesystem',
+          description: 'Rescans the project filesystem in the running editor so files written outside Godot become visible to it. Call this after creating or renaming a script that declares a class_name: until the editor scans, that class is missing from the global class list and lsp_get_diagnostics reports every use of it as an unknown type. The editor otherwise only scans when its window regains focus.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              projectPath: {
+                type: 'string',
+                description: 'Absolute path to project directory containing project.godot. Use the same path across all tool calls in a workflow.',
+              },
+              timeoutMs: {
+                type: 'number',
+                description: 'How long to wait for the scan to finish before returning anyway. Default 10000.',
+              },
+            },
+            required: ['projectPath'],
+          },
+        },
+        {
           name: 'list_scene_nodes',
           description: 'Returns complete scene tree structure with all nodes, types, and hierarchy. Use to understand scene organization before modifying. Returns nested tree with node paths.',
           inputSchema: {

--- a/src/tool-groups.ts
+++ b/src/tool-groups.ts
@@ -131,8 +131,8 @@ export const CORE_TOOL_GROUPS: Record<string, ToolGroupDefinition> = {
   },
   core_scene: {
     description: 'Scene creation, saving, node tree manipulation',
-    tools: ['create_scene', 'save_scene', 'list_scene_nodes', 'add_node', 'get_node_properties', 'set_node_properties', 'delete_node'],
-    keywords: ['scene', 'node', 'create scene', 'add node', 'delete node', 'node properties', 'scene tree'],
+    tools: ['create_scene', 'save_scene', 'list_scene_nodes', 'add_node', 'get_node_properties', 'set_node_properties', 'delete_node', 'rescan_filesystem'],
+    keywords: ['scene', 'node', 'create scene', 'add node', 'delete node', 'node properties', 'scene tree', 'rescan', 'refresh filesystem', 'reimport'],
   },
   core_script: {
     description: 'GDScript creation, modification, and analysis',


### PR DESCRIPTION
Adds `rescan_filesystem`, which scans the project in the running editor and waits for it to settle.

The editor only rescans when its window regains focus. So anything an agent writes stays invisible to it until a human clicks on Godot: the new `class_name` is not in the global class list, and `lsp_get_diagnostics` reports every use of it as an unknown type. That is godotengine/godot#42786, and there is no way to trigger it over LSP, `workspace/didChangeWatchedFiles` is ignored. The editor plugin is already inside the editor and the scene and resource tools already call `scan()` after writes, so it just needs exposing.

The waiting is on the TypeScript side because `execute_tool` wants a Dictionary back and not a coroutine, so the addon starts the scan and reports `scanning` and `importing`, and the handler polls with `statusOnly` until both are false or `timeoutMs` (default 10s) runs out.

Compact alias `project.rescan`, in the `core_scene` group.

`bun run ci` passes.
