### PR TITLE
fix(runtime): stop a busy port failing tools, and name the callable tool in the catalog

### DIFF
--- a/src/addon/godot_mcp_runtime/mcp_runtime_autoload.gd
+++ b/src/addon/godot_mcp_runtime/mcp_runtime_autoload.gd
@@ -71,7 +71,12 @@ func _start_server() -> void:
 	_server = TCPServer.new()
 	var error = _server.listen(_port)
 	if error != OK:
-		push_error("[MCP Runtime] Failed to start server on port %d: %s" % [_port, error])
+		# A warning, not an error. The usual cause is that another instance of this project
+		# already owns the port, which happens every time a tool runs a headless operation
+		# while the game is open. This instance carries on without a runtime server, which
+		# is what it wants anyway, and callers treat any ERROR line on stderr as a failed
+		# operation, so reporting a handled condition as one breaks working tools.
+		push_warning("[MCP Runtime] Port %d is unavailable (%s), running without a server" % [_port, error])
 		_enabled = false
 	else:
 		print("[MCP Runtime] Server listening on port %d" % _port)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1110,9 +1110,18 @@ class GodotServer {
 
     const items = filtered.slice(0, limit).map((tool) => {
       const groupInfo = toolToGroup.get(tool.name) || null;
+      const compactAlias = reverseAlias.get(tool.name) || null;
       return {
         tool: tool.name,
-        compactAlias: reverseAlias.get(tool.name) || null,
+        compactAlias,
+        // The name to actually pass to tools/call. A tool without a compact alias is not
+        // uncallable: once its group is active it is exposed under its sanitized name,
+        // where underscores are hyphens. Reporting only a null alias reads as "this tool
+        // cannot be called", which is how it was read in #74.
+        callAs: compactAlias || this.sanitizeExportedToolName(tool.name),
+        requiresGroupActivation: Boolean(
+          !compactAlias && groupInfo?.type === 'dynamic' && !this.activeGroups.has(groupInfo.group),
+        ),
         group: groupInfo?.group || null,
         groupType: groupInfo?.type || null,
         description: tool.description,


### PR DESCRIPTION
Closes #74, both halves.

**Port 7777.** When the game is already running, a headless operation instance cannot bind the port, and the autoload calls `push_error`. It already handles the case correctly by setting `_enabled = false` and carrying on, so the error is a label on a condition that is fine. It matters because callers do this:

```ts
if (stderr && stderr.includes('ERROR')) {
  return this.createErrorResponse(...)
}
```

So `get_project_setting` reports a failure for an operation that in fact succeeded, which is exactly what the reporter saw. It is a `push_warning` now.

**Testing tools.** These are callable, and the report is still right that you cannot tell. Activating the `testing` group exposes them, but under their sanitized names, so it is `capture-screenshot` with hyphens and not `capture_screenshot`. Meanwhile the catalog says `compactAlias: null`, which reads as "this tool cannot be called".

I did not add compact aliases for them: compact tools are exposed unconditionally, so that would put the testing tools in every session and defeat the point of holding them behind a dynamic group. The catalog now reports the name that works instead:

```json
{"tool": "capture_screenshot", "compactAlias": null, "callAs": "capture-screenshot", "requiresGroupActivation": false, "group": "testing"}
```

`requiresGroupActivation` says whether the group still needs turning on first.

Checked against a running server: after activating `testing`, `capture-screenshot` reaches the runtime and fails only with "Failed to connect to Godot runtime addon at 127.0.0.1:7777", which is the right answer with no game open.

`bun run ci` passes.
