### PR TITLE
fix(dependencies): make depth and includeBuiltin work, and stop skipping addons

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4655,10 +4655,19 @@ class GodotServer {
         );
       }
 
+      // The operation script reads `max_depth` and `include_built_in`. These were sent as
+      // `depth` and `includeBuiltin`, which become `depth` and `include_builtin`, so
+      // neither ever arrived: depth always fell back to the script's own 10, and built-ins
+      // were skipped no matter what the caller asked for.
+      //
+      // A negative depth means unlimited in this tool's schema. The script has no notion of
+      // that and compares `current_depth >= max_depth`, so passing -1 straight through
+      // would return nothing at all.
+      const requested = args.depth !== undefined ? Number(args.depth) : -1;
       const params: any = {
         resourcePath: args.resourcePath,
-        depth: args.depth !== undefined ? args.depth : -1,
-        includeBuiltin: args.includeBuiltin || false,
+        maxDepth: Number.isFinite(requested) && requested >= 0 ? requested : 100,
+        includeBuiltIn: args.includeBuiltin || false,
       };
 
       const { stdout, stderr } = await this.executeOperation('get_dependencies', params, args.projectPath);

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -1768,8 +1768,10 @@ func analyze_resource_dependencies(path: String, max_depth: int, current_depth: 
                 if not dep_path.begins_with("res://"):
                     continue
                 
-                # Skip built-in resources unless requested
-                if not include_built_in and (dep_path.contains("addons/") or dep_path.begins_with("res://.")):
+                # Skip engine-internal resources unless requested. `addons/` is not one of
+                # them: it is ordinary project content, and often shipping content, so
+                # treating it as built-in dropped every dependency of anything living there.
+                if not include_built_in and dep_path.begins_with("res://."):
                     continue
                 
                 # Skip if same as source

--- a/test-regressions.mjs
+++ b/test-regressions.mjs
@@ -267,6 +267,17 @@ async function main() {
     'runtime key injection should treat string keycode values as key labels',
   );
 
+  assert.doesNotMatch(
+    OPERATIONS_SOURCE,
+    /include_built_in and \(dep_path\.contains\("addons\/"\)/,
+    'addons/ is project content and often ships, so dependency analysis must not skip it as built-in',
+  );
+  assert.match(
+    INDEX_SOURCE,
+    /maxDepth:[\s\S]*?includeBuiltIn:/,
+    'get_dependencies must send the names the operation script reads, max_depth and include_built_in',
+  );
+
   await testEditorStatusPortConflict();
   console.log('regression tests passed');
 }


### PR DESCRIPTION
`get_dependencies` reports nothing for anything under `addons/`. Two separate causes.

**The arguments never arrive.** The handler sends:

```ts
{ resourcePath, depth, includeBuiltin }
```

`convertCamelToSnakeCase` turns those into `resource_path`, `depth`, `include_builtin`. The operation script reads `resource_path`, `max_depth` and `include_built_in`, so only the first matches. `depth` is silently ignored and falls back to the script's own 10, and `includeBuiltin` does nothing whatever the caller passes. Sending `maxDepth` and `includeBuiltIn` produces the names the script actually reads.

The schema also documents `-1` as unlimited, which the script has no notion of: it compares `current_depth >= max_depth`, so passing `-1` straight through returns nothing at all. It becomes a depth nothing realistically nests past.

**`addons/` is treated as built-in.** The second commit:

```gdscript
if not include_built_in and (dep_path.contains("addons/") or dep_path.begins_with("res://.")):
```

Addons are ordinary project content and frequently shipping content, so a material or scene living there had every dependency dropped. Engine-internal paths under `res://.` still are skipped.

How this showed up: a `ShaderMaterial` in `addons/` with two `ext_resource` lines, a shader and a texture, reported `total_dependencies: 0`. Passing `includeBuiltin: true` changed nothing, which is what pointed at the plumbing rather than the filter.

Both commits stand alone if you only want one.

`bun run ci` passes.
